### PR TITLE
Update orgmode.tmLanguage

### DIFF
--- a/orgmode.tmLanguage
+++ b/orgmode.tmLanguage
@@ -29,9 +29,9 @@
 			<key>name</key>
 			<string>orgmode.headline</string>
 			<key>match</key>
-			<string>^\s*[*]+ [^\[\]:\n]*</string>
+			<string>^\s{0,}\*+.*\*</string>
 		</dict>
-				<dict>
+		<dict>
 			<key>name</key>
 			<string>orgmode.deadline</string>
 			<key>match</key>


### PR DESCRIPTION
Cleaned up the scope. This allows headings to be left justified or indented in (h2+). By indenting after h1, it allows folding of children by the parent.
